### PR TITLE
Fix rotation check and comparator

### DIFF
--- a/RBTreeImpl/RBTreeImpl.h
+++ b/RBTreeImpl/RBTreeImpl.h
@@ -223,13 +223,17 @@ namespace Datastr{
         RedBlackTree(const RedBlackTree &other) = delete;
         const RedBlackTree& operator=(const RedBlackTree &other) = delete;
 
-        RedBlackTree(RedBlackTree &&other){
-            operator=(std::move(other));
+        RedBlackTree(RedBlackTree &&other) noexcept{
+            pTreeImpl = std::move(other.pTreeImpl);
+            comparator = std::move(other.comparator);
         }
 
         const RedBlackTree&
-        operator=(RedBlackTree &&other){
-            pTreeImpl = std::move(other);
+        operator=(RedBlackTree &&other) noexcept{
+            if(this != &other){
+                pTreeImpl = std::move(other.pTreeImpl);
+                comparator = std::move(other.comparator);
+            }
             return (*this);
         }
 
@@ -243,13 +247,17 @@ namespace Datastr{
             }
 
             if(!pTreeImpl){
+                delete compoundKey;
                 return false;
             }
 
-            int res =
-            pTreeImpl->insert(
+            int res = pTreeImpl->insert(
                     pTreeImpl.get(),
                     static_cast<void*>(compoundKey));
+
+            if(!res){
+                delete compoundKey;
+            }
 
             return (res);
         }

--- a/RBTreeImpl/main.cpp
+++ b/RBTreeImpl/main.cpp
@@ -11,8 +11,11 @@ struct P{
 
 int main(){
     Datastr::RedBlackTree<P> tree([](const P& p1, const P& p2)->int{
-       return p1.i < p2.i || (p1.i == p2.i && p1.j < p2.j) ? 1 :
-              (p1.i == p2.i && p1.j == p2.j ? 0 : -1);
+       if(p1.i < p2.i || (p1.i == p2.i && p1.j < p2.j))
+           return -1;
+       if(p1.i == p2.i && p1.j == p2.j)
+           return 0;
+       return 1;
     });
 
     tree.insert({1,2});

--- a/src/RBTree.c
+++ b/src/RBTree.c
@@ -58,7 +58,7 @@
              *newParent = NULL,
              *newParentSon = NULL;
 
-        if(!rot && !(*rot)){
+        if(!rot || !(*rot)){
           return;
         }
 


### PR DESCRIPTION
## Summary
- correct null check in rotate utility
- fix ordering logic in the sample C++ comparator

## Testing
- `cmake .. -DCMAKE_C_FLAGS='-Wall -Wextra -pedantic' -DCMAKE_CXX_FLAGS='-Wall -Wextra -pedantic'`
- `make -j$(nproc)`
- `./RBTreeImpl/RBTreeImpl`
- `valgrind ./RBTreeImpl/RBTreeImpl`


------
https://chatgpt.com/codex/tasks/task_e_68452a7ee83083289ab947f22d86f9f8